### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add to dependencies
 
 ```elixir
 def deps do
-  [{:fcmex, "~> 0.1.1"}]
+  [{:fcmex, "~> 0.1.2"}]
 end
 ```
 
@@ -49,7 +49,7 @@ config :fcmex,
 - Send messsage to the topic
 
 ```elixir
-{:ok, body} = Fcmex.push("/topic_name",
+{:ok, body} = Fcmex.push("/topics/_name",
   notification: %{
     title: "foo",
     body: "bar",


### PR DESCRIPTION
Updated the hex dep version.

As well I updated the topic send example since for sending a message to a topics [it's required the following format](https://firebase.google.com/docs/cloud-messaging/http-server-ref) `/topics/$topic`

As a suggestion, I would consider validating the correct format and five user info about this error, since the one from Google it's not clear enough (returns an error `%{"error" => "InvalidRegistration"}`). Or even I would consider prepending the `/topics/` string to the given one if does not match the required format.