### PR TITLE
Update retry to 0.10.0

### DIFF
--- a/lib/fcmex/subscription.ex
+++ b/lib/fcmex/subscription.ex
@@ -65,7 +65,10 @@ defmodule Fcmex.Subscription do
   defp request(func) do
     retry with: exp_backoff() |> randomize |> expiry(10_000) do
       func.()
+    after
+      result -> Util.parse_result(result)
+    else
+      error -> error
     end
-    |> Util.parse_result()
   end
 end

--- a/lib/request.ex
+++ b/lib/request.ex
@@ -18,6 +18,10 @@ defmodule Fcmex.Request do
   defp post(%Payload{} = payload) do
     retry with: exp_backoff() |> randomize |> expiry(10_000) do
       HTTPoison.post(@fcm_endpoint, payload |> Poison.encode!(), Config.new())
+    after
+      result -> result
+    else
+      error -> error
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -41,7 +41,7 @@ defmodule Fcmex.Mixfile do
       {:httpoison, ">= 0.0.0"},
       {:poison, ">= 0.0.0"},
       {:flow, "~> 0.12"},
-      {:retry, "~> 0.7"},
+      {:retry, "~> 0.10.0"},
       {:credo, "~> 0.8", only: [:dev, :test], runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:exvcr, ">= 0.0.0", only: [:test, :dev]},

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
+%{
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
   "certifi": {:hex, :certifi, "1.2.1", "c3904f192bd5284e5b13f20db3ceac9626e14eeacfbb492e19583cf0e37b22be", [:rebar3], []},
   "credo": {:hex, :credo, "0.8.1", "137efcc99b4bc507c958ba9b5dff70149e971250813cbe7d4537ec7e36997402", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
   "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], []},
@@ -17,6 +18,7 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
-  "retry": {:hex, :retry, "0.7.0", "894a32223433501b33e95cc54bda72f3d162a930d2eba749ed7766f05721986d", [:mix], []},
+  "retry": {:hex, :retry, "0.10.0", "5bdebcc88716aded650cbcd216dbf2cf05989d29335ae94d97752e970a816d86", [:mix], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
-  "unicode_util_compat": {:hex, :unicode_util_compat, "0.2.0", "dbbccf6781821b1c0701845eaf966c9b6d83d7c3bfc65ca2b78b88b8678bfa35", [:rebar3], []}}
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.2.0", "dbbccf6781821b1c0701845eaf966c9b6d83d7c3bfc65ca2b78b88b8678bfa35", [:rebar3], []},
+}


### PR DESCRIPTION
Fixes #8 

I also updated dep spec for retry to `"~> 0.10.0"` (including the revision number) - traditionally before 1.0 backward incompatible api changes are allowed if you bump the major version and I didn't want such a situation to break the library again.