### PR TITLE
Fix deprecated warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: elixir
 matrix:
   include:
-    - elixir: 1.5.0
+    - elixir: 1.5
       otp_release: 19.3
     - elixir: 1.6
       otp_release: 19.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 language: elixir
-elixir:
-  - 1.5.0
-otp_release:
-  - 19.1
+matrix:
+  include:
+    - elixir: 1.5.0
+      otp_release: 19.3
+    - elixir: 1.6
+      otp_release: 19.3
+    - elixir: 1.7
+      otp_release: 21.0
+    - elixir: 1.8
+      otp_release: 21.0
+    - elixir: 1.9
+      otp_release: 22.0
 sudo: false
 env:
   - MIX_ENV=test FCM_SERVER_KEY=non_empty_secret_key_string

--- a/lib/fcmex.ex
+++ b/lib/fcmex.ex
@@ -20,7 +20,7 @@ defmodule Fcmex do
   def push(to, opts) when is_list(to) do
     to
     |> Enum.reject(&is_nil(&1))
-    |> Enum.chunk(1000, 1000, [])
+    |> Enum.chunk_every(1000)
     |> Enum.map(&%{to: &1})
     |> Flow.from_enumerable(stages: @max_concurrent_connection)
     |> Flow.map(&Request.perform(&1.to, opts))
@@ -46,7 +46,7 @@ defmodule Fcmex do
   @spec filter_unregistered_tokens(list) :: list(binary)
   def filter_unregistered_tokens(tokens) when is_list(tokens) do
     tokens
-    |> Enum.chunk(1000, 1000, [])
+    |> Enum.chunk_every(1000)
     |> Flow.from_enumerable(stages: @max_concurrent_connection)
     |> Flow.map(&%{tokens: &1, results: Request.perform(&1, data: %{})})
     |> Enum.to_list()

--- a/mix.lock
+++ b/mix.lock
@@ -14,7 +14,7 @@
   "httpoison": {:hex, :httpoison, "0.11.2", "9e59f17a473ef6948f63c51db07320477bad8ba88cf1df60a3eee01150306665", [:mix], [{:hackney, "~> 1.8.0", [hex: :hackney, optional: false]}]},
   "idna": {:hex, :idna, "5.0.2", "ac203208ada855d95dc591a764b6e87259cb0e2a364218f215ad662daa8cd6b4", [:rebar3], [{:unicode_util_compat, "0.2.0", [hex: :unicode_util_compat, optional: false]}]},
   "jsx": {:hex, :jsx, "2.8.2", "7acc7d785b5abe8a6e9adbde926a24e481f29956dd8b4df49e3e4e7bcc92a018", [:mix, :rebar3], []},
-  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:make, :rebar], []},
+  "meck": {:hex, :meck, "0.8.13", "ffedb39f99b0b99703b8601c6f17c7f76313ee12de6b646e671e3188401f7866", [:rebar3], [], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},


### PR DESCRIPTION
I got deprecated warning on deps.get as bellow,

```
==> fcmex
Compiling 6 files (.ex)
warning: Enum.chunk/4 is deprecated. Use Enum.chunk_every/4 instead
Found at 2 locations:
  lib/fcmex.ex:23
  lib/fcmex.ex:49

Generated fcmex app
```

and also got an error on fcmex compilation

```
==> meck (compile)
Compiled src/meck_ret_spec.erl
Compiled src/meck_expect.erl
Compiled src/meck.erl
Compiled src/meck_util.erl
Compiled src/meck_matcher.erl
Compiled src/meck_history.erl
Compiled src/meck_code.erl
Compiled src/meck_cover.erl
Compiled src/meck_args_matcher.erl
src/meck_code_gen.erl:185: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
Compiling src/meck_code_gen.erl failed:
ERROR: compile failed while processing /Users/nukosuke/workplace/github.com/nukosuke/fcmex/deps/meck: rebar_abort
==> fcmex
** (Mix) Could not compile dependency :meck, "/Users/nukosuke/.asdf/installs/elixir/1.7.3-otp-21/.mix/rebar compile skip_deps=true deps_dir="/Users/nukosuke/workplace/github.com/nukosuke/fcmex/_build/dev/lib"" command failed. You can recompile this dependency with "mix deps.compile meck", update it with "mix deps.update meck" or clean it with "mix deps.clean meck"
```

-----

This PR
- upgrade meck from 0.8.4 to 0.8.13
- use [chunk_every/4](https://hexdocs.pm/elixir/Enum.html#chunk_every/2) instead of chunk(deprecated)