### PR TITLE
Allow passing an endpoint option to HTTPoison on call

### DIFF
--- a/lib/request.ex
+++ b/lib/request.ex
@@ -10,15 +10,17 @@ defmodule Fcmex.Request do
 
   def perform(to, opts) do
     with payload <- Payload.create(to, opts),
-         result <- post(payload) do
+         result <- post(payload, opts) do
       Util.parse_result(result)
     end
   end
 
-  defp post(%Payload{} = payload) do
+  defp post(%Payload{} = payload, opts) do
+    endpoint = Keyword.get(opts, :endpoint, @fcm_endpoint)
+
     retry with: exp_backoff() |> randomize |> expiry(10_000) do
       HTTPoison.post(
-        @fcm_endpoint,
+        endpoint,
         payload |> Poison.encode!(),
         Config.new(),
         Config.httpoison_options()


### PR DESCRIPTION
This is useful for testing with bypass (https://github.com/PSPDFKit-labs/bypass), where a specific port on localhost must receive http requests for it to function.

The change itself is quite simple. I'm happy to add a test to cover this behavior.