### PR TITLE
Support newer elixir versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: '1.8.x'
-            otp: '21.0'
           - elixir: '1.9.x'
             otp: '22.0'
           - elixir: '1.10.x'
             otp: '23.0'
           - elixir: '1.11.x'
+            otp: '23.0'
+          - elixir: '1.12.x'
+            otp: '23.0'
+          - elixir: '1.13.x'
             otp: '23.0'
     env:
       MIX_ENV: test

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+# and its dependencies with the aid of the Config module.
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
@@ -10,11 +10,11 @@ use Mix.Config
 
 # You can configure for your application as:
 #
-#     config :fcm, key: :value
+#     config :fcmex, key: :value
 #
 # And access this configuration in your application as:
 #
-#     Application.get_env(:fcm, :key)
+#     Application.get_env(:fcmex, :key)
 #
 # Or configure a 3rd-party app:
 #


### PR DESCRIPTION
Hi,

This PR will add some newer versions of Elixir to CI matrix.

## changes
- drop support for v1.8 (EOL)
- add support for v1.12 and v1.13
- migrate obsolete `Mix.Config` module to `Config` (available since v1.9)