### PR TITLE
Enable fcmex to use alternative JSON library to encode/decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,23 @@ config :fcmex,
   httpoison_options: [ssl: [{:versions, [:'tlsv1.2']}], recv_timeout: 500]
 ```
 
+`fcmex` uses `Poison` to encode/decode JSON by default. If you want to use alternative library like [`Jason`](https://github.com/michalmuskala/jason), add the package to `mix.exs` and set the module to config.
+
+```elixir
+# mix.exs
+def deps do
+ [
+   ...,
+   {:jason, "~> 1.3"}
+ ]
+end
+```
+
+```elixir
+# config/config.exs
+config :fcmex, :json_library, Jason
+```
+
 ## Testing
 
 If you start contributing and you want to run mix test, first you need to export FCM_SERVER_KEY environment variable in the same shell as the one you will be running mix test in.

--- a/lib/config.ex
+++ b/lib/config.ex
@@ -22,4 +22,8 @@ defmodule Fcmex.Config do
   def httpoison_options() do
     Application.get_env(:fcmex, :httpoison_options, [])
   end
+
+  def json_library do
+    Application.get_env(:fcmex, :json_library, Poison)
+  end
 end

--- a/lib/fcmex/subscription.ex
+++ b/lib/fcmex/subscription.ex
@@ -41,7 +41,7 @@ defmodule Fcmex.Subscription do
     request(fn ->
       HTTPoison.post(
         "#{@base_url}#{@endpoint}:batchAdd",
-        body |> Poison.encode!(),
+        body |> Config.json_library().encode!(),
         Config.new(),
         Config.httpoison_options()
       )
@@ -58,7 +58,12 @@ defmodule Fcmex.Subscription do
     url = "#{@base_url}#{@endpoint}:batchRemove"
 
     request(fn ->
-      HTTPoison.post(url, body |> Poison.encode!(), Config.new(), Config.httpoison_options())
+      HTTPoison.post(
+        url,
+        body |> Config.json_library().encode!(),
+        Config.new(),
+        Config.httpoison_options()
+      )
     end)
   end
 
@@ -72,7 +77,12 @@ defmodule Fcmex.Subscription do
     url = "#{@base_url}#{@endpoint}:batchRemove"
 
     request(fn ->
-      HTTPoison.post(url, body |> Poison.encode!(), Config.new(), Config.httpoison_options())
+      HTTPoison.post(
+        url,
+        body |> Config.json_library().encode!(),
+        Config.new(),
+        Config.httpoison_options()
+      )
     end)
   end
 

--- a/lib/request.ex
+++ b/lib/request.ex
@@ -21,7 +21,7 @@ defmodule Fcmex.Request do
     retry with: exponential_backoff() |> randomize |> expiry(10_000) do
       HTTPoison.post(
         endpoint,
-        payload |> Poison.encode!(),
+        payload |> Config.json_library().encode!(),
         Config.new(),
         Config.httpoison_options()
       )

--- a/lib/util.ex
+++ b/lib/util.ex
@@ -5,6 +5,7 @@ defmodule Fcmex.Util do
 
   alias HTTPoison.Response
   alias HTTPoison.Error
+  alias Fcmex.Config
 
   @success_status 200..299
   @client_error_status 400..499
@@ -16,19 +17,19 @@ defmodule Fcmex.Util do
   ## Examples
 
       iex> Fcmex.Util.parse_result({:ok, %HTTPoison.Response{status_code: 200, body: "{\"a\": 1}"}})
-      {:ok, Poison.decode!("{\"a\": 1}")}
+      {:ok, %{"a" => 1}}
 
       iex> Fcmex.Util.parse_result({:error, %HTTPoison.Error{id: 1, reason: "something goes wrong"}})
       {:error, %HTTPoison.Error{id: 1, reason: "something goes wrong"}}
   """
   def parse_result({:ok, %Response{status_code: status, body: body}})
       when status in @success_status,
-      do: {:ok, Poison.decode!(body)}
+      do: {:ok, Config.json_library().decode!(body)}
 
   def parse_result({:ok, %Response{status_code: status, body: body}})
       when status in @client_error_status do
     body
-    |> Poison.decode()
+    |> Config.json_library().decode()
     |> case do
       {:ok, decoded} -> {:error, decoded}
       {:error, _} -> {:error, body}


### PR DESCRIPTION
This PR enables fcmex to use alternative JSON library

## changes
- add new config `:json_library` and load it from `Config` module
- replace direct `Poison` calls to `Config.json_library()`

see README diff for details 🙏 